### PR TITLE
Changed lessfuel to use built in fuel file create for easier debugging

### DIFF
--- a/classes/asset.php
+++ b/classes/asset.php
@@ -39,11 +39,11 @@ class Asset extends \Fuel\Core\Asset
 			$path = DOCROOT.$path.\Config::get('asset.css_dir');
 		}
 
-		$include_paths[] = APPPATH.\Config::get('less.path');
+		$include_paths[] = \Config::get('less.path');
 		
 		foreach($stylesheets as &$lessfile)
 		{
-			$source_less  = APPPATH.\Config::get('less.path').$lessfile;
+			$source_less  = \Config::get('less.path').$lessfile;
 			$compile_path = DOCROOT.\Arr::get(\Config::get('asset.paths'), \Config::get('less.default_path_key')).\Config::get('asset.css_dir');
 			$css_name     = pathinfo($lessfile, PATHINFO_FILENAME).'.css';
 			$compiled_css = $compile_path.$css_name;

--- a/classes/asset.php
+++ b/classes/asset.php
@@ -14,7 +14,8 @@
 
 namespace Less;
 
-class Asset extends \Fuel\Core\Asset {
+class Asset extends \Fuel\Core\Asset
+{
 
 	public static function _init()
 	{
@@ -25,32 +26,37 @@ class Asset extends \Fuel\Core\Asset {
 	
 	public static function less($stylesheets = array(), $attr = array(), $group = NULL, $raw = false)
 	{
-		if (!is_array($stylesheets)) {
+		if ( ! is_array($stylesheets))
+		{
 			$stylesheets = array($stylesheets);
 		}
 		
 		// Get all the asset CSS paths (for a better @include integration)
 		$include_paths = \Config::get('asset.paths');
 
-		foreach ($include_paths as &$path) {
-			$path = DOCROOT . $path . \Config::get('asset.css_dir');
+		foreach($include_paths as &$path)
+		{
+			$path = DOCROOT.$path.\Config::get('asset.css_dir');
 		}
 
-		$include_paths[] = APPPATH . \Config::get('less.path');
+		$include_paths[] = APPPATH.\Config::get('less.path');
 		
-		foreach ($stylesheets as &$lessfile) {
-			$source_less = APPPATH . \Config::get('less.path') . $lessfile;
-			$compile_path = DOCROOT . \Arr::get(\Config::get('asset.paths'), \Config::get('less.default_path_key')) . \Config::get('asset.css_dir');
-			$css_name = pathinfo($lessfile, PATHINFO_FILENAME).'.css';
-			$compiled_css = $compile_path . $css_name;
+		foreach($stylesheets as &$lessfile)
+		{
+			$source_less  = APPPATH.\Config::get('less.path').$lessfile;
+			$compile_path = DOCROOT.\Arr::get(\Config::get('asset.paths'), \Config::get('less.default_path_key')).\Config::get('asset.css_dir');
+			$css_name     = pathinfo($lessfile, PATHINFO_FILENAME).'.css';
+			$compiled_css = $compile_path.$css_name;
 			
-			if (!is_file($source_less)) {
-				throw new \Fuel_Exception('Could not find lesscss source file: ' . $source_less);
+			if ( ! is_file($source_less))
+			{
+				throw new \Fuel_Exception('Could not find lesscss source file: '.$source_less);
 			}
 			
 			// Compile only if source is newer than compiled file
-			if (!is_file($compiled_css) || filemtime($source_less) > filemtime($compiled_css)) {
-				require_once PKGPATH . 'less' . DS . 'vendor' . DS . 'lessphp' . DS . 'lessc.inc.php';
+			if ( ! is_file($compiled_css) || filemtime($source_less) > filemtime($compiled_css))
+			{
+				require_once PKGPATH.'less'.DS.'vendor'.DS.'lessphp'.DS.'lessc.inc.php';
 				
 				$handle = new \lessc($source_less);
 				$handle->importDir = $include_paths;
@@ -60,9 +66,10 @@ class Asset extends \Fuel\Core\Asset {
 			}
 			
 			// Change the name to load as CSS asset
-			$lessfile = str_replace(pathinfo($lessfile, PATHINFO_EXTENSION), '', $lessfile) . 'css';
+			$lessfile = str_replace(pathinfo($lessfile, PATHINFO_EXTENSION), '', $lessfile).'css';
 		}
 		
 		return static::css($stylesheets, $attr, $group, $raw);
 	}
+	
 }

--- a/classes/asset.php
+++ b/classes/asset.php
@@ -19,41 +19,36 @@ class Asset extends \Fuel\Core\Asset {
 	public static function _init()
 	{
 		parent::_init();
+		
 		\Config::load('less', true);
 	}
 	
 	public static function less($stylesheets = array(), $attr = array(), $group = NULL, $raw = false)
 	{
-		if(!is_array($stylesheets))
-		{
+		if (!is_array($stylesheets)) {
 			$stylesheets = array($stylesheets);
 		}
 		
 		// Get all the asset CSS paths (for a better @include integration)
 		$include_paths = \Config::get('asset.paths');
-		foreach($include_paths as &$path)
-		{
-			$path = DOCROOT.$path.\Config::get('asset.css_dir');
+
+		foreach ($include_paths as &$path) {
+			$path = DOCROOT . $path . \Config::get('asset.css_dir');
 		}
-		$include_paths[] = APPPATH.\Config::get('less.path');
+
+		$include_paths[] = APPPATH . \Config::get('less.path');
 		
-		foreach($stylesheets as &$lessfile)
-		{
-			$source_less	= APPPATH.\Config::get('less.path').$lessfile; // Name of source filename
-			$compiled_css	= DOCROOT.\Arr::get(\Config::get('asset.paths'), \Config::get('less.default_path_key')).\Config::get('asset.css_dir').pathinfo($lessfile, PATHINFO_FILENAME).'.css'; // Name of destination CSS compiled file
+		foreach ($stylesheets as &$lessfile) {
+			$source_less = APPPATH . \Config::get('less.path') . $lessfile;
+			$compiled_css = DOCROOT . \Arr::get(\Config::get('asset.paths'), \Config::get('less.default_path_key')) . \Config::get('asset.css_dir') . pathinfo($lessfile, PATHINFO_FILENAME) . '.css';
 			
-			if(!is_file($source_less))
-			{
-				throw new \Fuel_Exception('Could not find lesscss source file: '.$source_less);
+			if (!is_file($source_less)) {
+				throw new \Fuel_Exception('Could not find lesscss source file: ' . $source_less);
 			}
 			
 			// Compile only if source is newer than compiled file
-			if (!is_file($compiled_css) || filemtime($source_less) > filemtime($compiled_css))
-			{
-				// I found this ugly way, but seems to be a little faster
-				// than including it on every call to Asset::less when
-				// the files are already compiled
-				require_once PKGPATH.'less'.DS.'vendor'.DS.'lessphp'.DS.'lessc.inc.php';
+			if (!is_file($compiled_css) || filemtime($source_less) > filemtime($compiled_css)) {
+				require_once PKGPATH . 'less' . DS . 'vendor' . DS . 'lessphp' . DS . 'lessc.inc.php';
 				
 				$handle = new \lessc($source_less);
 				$handle->importDir = $include_paths;
@@ -62,7 +57,7 @@ class Asset extends \Fuel\Core\Asset {
 			}
 			
 			// Change the name to load as CSS asset
-			$lessfile = str_replace(pathinfo($lessfile, PATHINFO_EXTENSION), '', $lessfile).'css';
+			$lessfile = str_replace(pathinfo($lessfile, PATHINFO_EXTENSION), '', $lessfile) . 'css';
 		}
 		
 		return static::css($stylesheets, $attr, $group, $raw);

--- a/classes/asset.php
+++ b/classes/asset.php
@@ -40,7 +40,7 @@ class Asset extends \Fuel\Core\Asset {
 		
 		foreach ($stylesheets as &$lessfile) {
 			$source_less = APPPATH . \Config::get('less.path') . $lessfile;
-			$compile_path = DOCROOT . \Arr::element(\Config::get('asset.paths'), \Config::get('less.default_path_key')) . \Config::get('asset.css_dir');
+			$compile_path = DOCROOT . \Arr::get(\Config::get('asset.paths'), \Config::get('less.default_path_key')) . \Config::get('asset.css_dir');
 			$css_name = pathinfo($lessfile, PATHINFO_FILENAME).'.css';
 			$compiled_css = $compile_path . $css_name;
 			

--- a/classes/asset.php
+++ b/classes/asset.php
@@ -56,7 +56,7 @@ class Asset extends \Fuel\Core\Asset {
 				$handle->importDir = $include_paths;
 				$handle->indentChar = '	'; // Tab instead 2 spaces
 				
-				\File::create($compile_path, $css_name, $handle->parse());
+				\File::update($compile_path, $css_name, $handle->parse());
 			}
 			
 			// Change the name to load as CSS asset

--- a/classes/asset.php
+++ b/classes/asset.php
@@ -40,7 +40,9 @@ class Asset extends \Fuel\Core\Asset {
 		
 		foreach ($stylesheets as &$lessfile) {
 			$source_less = APPPATH . \Config::get('less.path') . $lessfile;
-			$compiled_css = DOCROOT . \Arr::get(\Config::get('asset.paths'), \Config::get('less.default_path_key')) . \Config::get('asset.css_dir') . pathinfo($lessfile, PATHINFO_FILENAME) . '.css';
+			$compile_path = DOCROOT . \Arr::element(\Config::get('asset.paths'), \Config::get('less.default_path_key')) . \Config::get('asset.css_dir');
+			$css_name = pathinfo($lessfile, PATHINFO_FILENAME).'.css';
+			$compiled_css = $compile_path . $css_name;
 			
 			if (!is_file($source_less)) {
 				throw new \Fuel_Exception('Could not find lesscss source file: ' . $source_less);
@@ -53,7 +55,8 @@ class Asset extends \Fuel\Core\Asset {
 				$handle = new \lessc($source_less);
 				$handle->importDir = $include_paths;
 				$handle->indentChar = '	'; // Tab instead 2 spaces
-				file_put_contents($compiled_css, $handle->parse());
+				
+				\File::create($compile_path, $css_name, $handle->parse());
 			}
 			
 			// Change the name to load as CSS asset

--- a/config/less.php
+++ b/config/less.php
@@ -28,7 +28,7 @@ return array(
 	 *
 	 * Default: 'less/'
 	 */
-	'path' => 'less/',
+	'path' => APPPATH.'less/',
 	
 	/**
 	 * As the asset config is a array with multiple paths, you must tell


### PR DESCRIPTION
Fuel's built in File class throws an exception which makes it easier when debugging on several different machines as to why writing a file isn't working due to permissions and such.
